### PR TITLE
Issue 56

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /.classpath
 /.project
 /bin/
+/screenshots/
+/videos/

--- a/src/main/java/com/github/wasiqb/coteafs/appium/android/AndroidDevice.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/android/AndroidDevice.java
@@ -15,6 +15,9 @@
  */
 package com.github.wasiqb.coteafs.appium.android;
 
+import static io.appium.java_client.android.AndroidStartScreenRecordingOptions.startScreenRecordingOptions;
+import static io.appium.java_client.android.AndroidStopScreenRecordingOptions.stopScreenRecordingOptions;
+
 import com.github.wasiqb.coteafs.appium.device.Device;
 import com.github.wasiqb.coteafs.appium.service.AppiumServer;
 
@@ -35,5 +38,30 @@ public class AndroidDevice extends Device <AndroidDriver <MobileElement>, Androi
 	 */
 	public AndroidDevice (final AppiumServer server, final String name) {
 		super (server, name);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see com.github.wasiqb.coteafs.appium.device.Device#startRecord()
+	 */
+	@Override
+	protected void startRecord () {
+		if (this.setting.getPlayback ()
+			.isRecord ()) {
+			this.driver.startRecordingScreen (startScreenRecordingOptions ());
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see com.github.wasiqb.coteafs.appium.device.Device#stopRecord()
+	 */
+	@Override
+	protected void stopRecord () {
+		if (this.setting.getPlayback ()
+			.isRecord ()) {
+			final String content = this.driver.stopRecordingScreen (stopScreenRecordingOptions ());
+			saveRecording (content);
+		}
 	}
 }

--- a/src/main/java/com/github/wasiqb/coteafs/appium/android/AndroidDevice.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/android/AndroidDevice.java
@@ -15,6 +15,7 @@
  */
 package com.github.wasiqb.coteafs.appium.android;
 
+import com.github.wasiqb.coteafs.appium.config.RecordSetting;
 import com.github.wasiqb.coteafs.appium.device.Device;
 import com.github.wasiqb.coteafs.appium.service.AppiumServer;
 
@@ -46,7 +47,17 @@ public class AndroidDevice extends Device <AndroidDriver <MobileElement>, Androi
 	@SuppressWarnings ("unchecked")
 	@Override
 	protected AndroidStartScreenRecordingOptions startRecordSetting () {
-		return AndroidStartScreenRecordingOptions.startScreenRecordingOptions ();
+		final AndroidStartScreenRecordingOptions options = AndroidStartScreenRecordingOptions
+			.startScreenRecordingOptions ();
+		final RecordSetting record = this.setting.getPlayback ()
+			.getRecord ();
+		if (record.getBitRate () != 4) {
+			options.withBitRate (record.getBitRate ());
+		}
+		if (record.getSize () != null) {
+			options.withVideoSize (record.getSize ());
+		}
+		return options;
 	}
 
 	/*

--- a/src/main/java/com/github/wasiqb/coteafs/appium/android/AndroidDevice.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/android/AndroidDevice.java
@@ -15,14 +15,13 @@
  */
 package com.github.wasiqb.coteafs.appium.android;
 
-import static io.appium.java_client.android.AndroidStartScreenRecordingOptions.startScreenRecordingOptions;
-import static io.appium.java_client.android.AndroidStopScreenRecordingOptions.stopScreenRecordingOptions;
-
 import com.github.wasiqb.coteafs.appium.device.Device;
 import com.github.wasiqb.coteafs.appium.service.AppiumServer;
 
 import io.appium.java_client.MobileElement;
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.android.AndroidStartScreenRecordingOptions;
+import io.appium.java_client.android.AndroidStopScreenRecordingOptions;
 import io.appium.java_client.android.AndroidTouchAction;
 
 /**
@@ -42,26 +41,21 @@ public class AndroidDevice extends Device <AndroidDriver <MobileElement>, Androi
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.github.wasiqb.coteafs.appium.device.Device#startRecord()
+	 * @see com.github.wasiqb.coteafs.appium.device.Device#startRecordSetting()
 	 */
+	@SuppressWarnings ("unchecked")
 	@Override
-	protected void startRecord () {
-		if (this.setting.getPlayback ()
-			.isRecord ()) {
-			this.driver.startRecordingScreen (startScreenRecordingOptions ());
-		}
+	protected AndroidStartScreenRecordingOptions startRecordSetting () {
+		return AndroidStartScreenRecordingOptions.startScreenRecordingOptions ();
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.github.wasiqb.coteafs.appium.device.Device#stopRecord()
+	 * @see com.github.wasiqb.coteafs.appium.device.Device#stopRecordSetting()
 	 */
+	@SuppressWarnings ("unchecked")
 	@Override
-	protected void stopRecord () {
-		if (this.setting.getPlayback ()
-			.isRecord ()) {
-			final String content = this.driver.stopRecordingScreen (stopScreenRecordingOptions ());
-			saveRecording (content);
-		}
+	protected AndroidStopScreenRecordingOptions stopRecordSetting () {
+		return AndroidStopScreenRecordingOptions.stopScreenRecordingOptions ();
 	}
 }

--- a/src/main/java/com/github/wasiqb/coteafs/appium/config/PlaybackSetting.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/config/PlaybackSetting.java
@@ -27,6 +27,9 @@ public class PlaybackSetting {
 	private int		delayAfterTap;
 	private int		delayBeforeSwipe;
 	private int		delayBeforeTap;
+	private boolean	record;
+	private String	recordPath;
+	private String	recordPrefix;
 	private boolean	screenshotOnError;
 	private String	screenShotPath;
 	private String	screenShotPrefix;
@@ -46,6 +49,9 @@ public class PlaybackSetting {
 		this.screenShotPath = format ("%s/screenshots", System.getProperty ("user.dir"));
 		this.screenShotPrefix = "SCR";
 		this.screenshotOnError = false;
+		this.record = false;
+		this.recordPath = format ("%s/video", System.getProperty ("user.dir"));
+		this.recordPrefix = "VID";
 	}
 
 	/**
@@ -94,6 +100,24 @@ public class PlaybackSetting {
 	}
 
 	/**
+	 * @author wasiqb
+	 * @since Oct 9, 2018
+	 * @return the recordPath
+	 */
+	public String getRecordPath () {
+		return this.recordPath;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 9, 2018
+	 * @return the recordPrefix
+	 */
+	public String getRecordPrefix () {
+		return this.recordPrefix;
+	}
+
+	/**
 	 * @author wasiq.bhamla
 	 * @since Jan 18, 2018 9:35:15 PM
 	 * @return the screenShotPath
@@ -118,6 +142,15 @@ public class PlaybackSetting {
 	 */
 	public int getWaitForElementUntil () {
 		return this.waitForElementUntil;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 9, 2018
+	 * @return the record
+	 */
+	public boolean isRecord () {
+		return this.record;
 	}
 
 	/**
@@ -177,6 +210,36 @@ public class PlaybackSetting {
 	 */
 	public void setDelayBeforeTap (final int delayBeforeTap) {
 		this.delayBeforeTap = delayBeforeTap;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 9, 2018
+	 * @param record
+	 *            the record to set
+	 */
+	public void setRecord (final boolean record) {
+		this.record = record;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 9, 2018
+	 * @param recordPath
+	 *            the recordPath to set
+	 */
+	public void setRecordPath (final String recordPath) {
+		this.recordPath = recordPath;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 9, 2018
+	 * @param recordPrefix
+	 *            the recordPrefix to set
+	 */
+	public void setRecordPrefix (final String recordPrefix) {
+		this.recordPrefix = recordPrefix;
 	}
 
 	/**

--- a/src/main/java/com/github/wasiqb/coteafs/appium/config/PlaybackSetting.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/config/PlaybackSetting.java
@@ -22,18 +22,16 @@ import static java.lang.String.format;
  * @since Jan 18, 2018 9:32:14 PM
  */
 public class PlaybackSetting {
-	private int		defaultWait;
-	private int		delayAfterSwipe;
-	private int		delayAfterTap;
-	private int		delayBeforeSwipe;
-	private int		delayBeforeTap;
-	private boolean	record;
-	private String	recordPath;
-	private String	recordPrefix;
-	private boolean	screenshotOnError;
-	private String	screenShotPath;
-	private String	screenShotPrefix;
-	private int		waitForElementUntil;
+	private int				defaultWait;
+	private int				delayAfterSwipe;
+	private int				delayAfterTap;
+	private int				delayBeforeSwipe;
+	private int				delayBeforeTap;
+	private RecordSetting	record;
+	private boolean			screenshotOnError;
+	private String			screenShotPath;
+	private String			screenShotPrefix;
+	private int				waitForElementUntil;
 
 	/**
 	 * @author wasiq.bhamla
@@ -48,10 +46,8 @@ public class PlaybackSetting {
 		this.delayAfterSwipe = 0;
 		this.screenShotPath = format ("%s/screenshots", System.getProperty ("user.dir"));
 		this.screenShotPrefix = "SCR";
+		this.record = new RecordSetting ();
 		this.screenshotOnError = false;
-		this.record = false;
-		this.recordPath = format ("%s/videos", System.getProperty ("user.dir"));
-		this.recordPrefix = "VID";
 	}
 
 	/**
@@ -101,20 +97,11 @@ public class PlaybackSetting {
 
 	/**
 	 * @author wasiqb
-	 * @since Oct 9, 2018
-	 * @return the recordPath
+	 * @since Oct 13, 2018
+	 * @return the record
 	 */
-	public String getRecordPath () {
-		return this.recordPath;
-	}
-
-	/**
-	 * @author wasiqb
-	 * @since Oct 9, 2018
-	 * @return the recordPrefix
-	 */
-	public String getRecordPrefix () {
-		return this.recordPrefix;
+	public RecordSetting getRecord () {
+		return this.record;
 	}
 
 	/**
@@ -142,15 +129,6 @@ public class PlaybackSetting {
 	 */
 	public int getWaitForElementUntil () {
 		return this.waitForElementUntil;
-	}
-
-	/**
-	 * @author wasiqb
-	 * @since Oct 9, 2018
-	 * @return the record
-	 */
-	public boolean isRecord () {
-		return this.record;
 	}
 
 	/**
@@ -214,32 +192,12 @@ public class PlaybackSetting {
 
 	/**
 	 * @author wasiqb
-	 * @since Oct 9, 2018
+	 * @since Oct 13, 2018
 	 * @param record
 	 *            the record to set
 	 */
-	public void setRecord (final boolean record) {
+	public void setRecord (final RecordSetting record) {
 		this.record = record;
-	}
-
-	/**
-	 * @author wasiqb
-	 * @since Oct 9, 2018
-	 * @param recordPath
-	 *            the recordPath to set
-	 */
-	public void setRecordPath (final String recordPath) {
-		this.recordPath = recordPath;
-	}
-
-	/**
-	 * @author wasiqb
-	 * @since Oct 9, 2018
-	 * @param recordPrefix
-	 *            the recordPrefix to set
-	 */
-	public void setRecordPrefix (final String recordPrefix) {
-		this.recordPrefix = recordPrefix;
 	}
 
 	/**

--- a/src/main/java/com/github/wasiqb/coteafs/appium/config/PlaybackSetting.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/config/PlaybackSetting.java
@@ -50,7 +50,7 @@ public class PlaybackSetting {
 		this.screenShotPrefix = "SCR";
 		this.screenshotOnError = false;
 		this.record = false;
-		this.recordPath = format ("%s/video", System.getProperty ("user.dir"));
+		this.recordPath = format ("%s/videos", System.getProperty ("user.dir"));
 		this.recordPrefix = "VID";
 	}
 

--- a/src/main/java/com/github/wasiqb/coteafs/appium/config/RecordSetting.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/config/RecordSetting.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2017-2020, Wasiq Bhamla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.wasiqb.coteafs.appium.config;
+
+import static java.lang.String.format;
+
+import io.appium.java_client.ios.IOSStartScreenRecordingOptions.VideoQuality;
+
+/**
+ * @author wasiqb
+ * @since Oct 13, 2018
+ */
+public class RecordSetting {
+	private int				bitRate;
+	private int				duration;
+	private boolean			enabled;
+	private String			path;
+	private String			prefix;
+	private VideoQuality	quality;
+	private String			size;
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 */
+	public RecordSetting () {
+		this.duration = 3;
+		this.quality = VideoQuality.MEDIUM;
+		this.enabled = false;
+		this.path = format ("%s/videos", System.getProperty ("user.dir"));
+		this.prefix = "VID";
+		this.bitRate = 4;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @return the bitRate
+	 */
+	public int getBitRate () {
+		return this.bitRate;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @return the duration
+	 */
+	public int getDuration () {
+		return this.duration;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @return the path
+	 */
+	public String getPath () {
+		return this.path;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @return the prefix
+	 */
+	public String getPrefix () {
+		return this.prefix;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @return the quality
+	 */
+	public VideoQuality getQuality () {
+		return this.quality;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @return the size
+	 */
+	public String getSize () {
+		return this.size;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @return the enabled
+	 */
+	public boolean isEnabled () {
+		return this.enabled;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @param bitRate
+	 *            the bitRate to set
+	 */
+	public void setBitRate (final int bitRate) {
+		this.bitRate = bitRate;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @param duration
+	 *            the duration to set
+	 */
+	public void setDuration (final int duration) {
+		this.duration = duration;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @param enabled
+	 *            the enabled to set
+	 */
+	public void setEnabled (final boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @param path
+	 *            the path to set
+	 */
+	public void setPath (final String path) {
+		this.path = path;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @param prefix
+	 *            the prefix to set
+	 */
+	public void setPrefix (final String prefix) {
+		this.prefix = prefix;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @param quality
+	 *            the quality to set
+	 */
+	public void setQuality (final VideoQuality quality) {
+		this.quality = quality;
+	}
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @param size
+	 *            the size to set
+	 */
+	public void setSize (final String size) {
+		this.size = size;
+	}
+}

--- a/src/main/java/com/github/wasiqb/coteafs/appium/device/Device.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/device/Device.java
@@ -104,6 +104,9 @@ import com.google.common.reflect.TypeToken;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.MobileElement;
 import io.appium.java_client.TouchAction;
+import io.appium.java_client.screenrecording.BaseStartScreenRecordingOptions;
+import io.appium.java_client.screenrecording.BaseStopScreenRecordingOptions;
+import io.appium.java_client.screenrecording.CanRecordScreen;
 
 /**
  * @author wasiq.bhamla
@@ -172,7 +175,7 @@ public abstract class Device <D extends AppiumDriver <MobileElement>, T extends 
 		final PlatformType platform = this.setting.getPlatformType ();
 		startDriver (platform);
 		setImplicitWait ();
-		startRecord ();
+		startRecord ((CanRecordScreen) this.driver);
 	}
 
 	/**
@@ -182,7 +185,7 @@ public abstract class Device <D extends AppiumDriver <MobileElement>, T extends 
 	public void stop () {
 		final PlatformType platform = this.setting.getPlatformType ();
 		if (this.driver != null) {
-			stopRecord ();
+			stopRecord ((CanRecordScreen) this.driver);
 			quitApp (platform);
 			this.driver = null;
 		}
@@ -213,9 +216,24 @@ public abstract class Device <D extends AppiumDriver <MobileElement>, T extends 
 		}
 	}
 
-	protected abstract void startRecord ();
+	protected void startRecord (final CanRecordScreen screen) {
+		if (this.setting.getPlayback ()
+			.isRecord () && !this.setting.isCloudApp ()) {
+			screen.startRecordingScreen (startRecordSetting ());
+		}
+	}
 
-	protected abstract void stopRecord ();
+	protected abstract <X extends BaseStartScreenRecordingOptions <X>> X startRecordSetting ();
+
+	protected void stopRecord (final CanRecordScreen screen) {
+		if (this.setting.getPlayback ()
+			.isRecord () && !this.setting.isCloudApp ()) {
+			final String content = screen.stopRecordingScreen (stopRecordSetting ());
+			saveRecording (content);
+		}
+	}
+
+	protected abstract <Y extends BaseStopScreenRecordingOptions <Y>> Y stopRecordSetting ();
 
 	/**
 	 * @author wasiq.bhamla

--- a/src/main/java/com/github/wasiqb/coteafs/appium/device/DeviceActions.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/device/DeviceActions.java
@@ -48,11 +48,7 @@ import io.appium.java_client.TouchAction;
  * @since 26-Apr-2017 8:39:17 PM
  */
 public class DeviceActions <D extends AppiumDriver <MobileElement>, E extends Device <D, T>, T extends TouchAction <T>> {
-	private static final Logger log;
-
-	static {
-		log = LogManager.getLogger (DeviceActions.class);
-	}
+	private static final Logger log = LogManager.getLogger (DeviceActions.class);
 
 	/**
 	 * @author wasiq.bhamla
@@ -63,7 +59,8 @@ public class DeviceActions <D extends AppiumDriver <MobileElement>, E extends De
 	private static void copyFile (final File source, final String destination) {
 		try {
 			FileUtils.copyFile (source, new File (destination));
-		} catch (final IOException e) {
+		}
+		catch (final IOException e) {
 			log.error ("Error occurred while capturing screensshot...");
 			log.catching (e);
 		}
@@ -98,7 +95,7 @@ public class DeviceActions <D extends AppiumDriver <MobileElement>, E extends De
 		final String prefix = this.setting.getScreenShotPrefix ();
 		final SimpleDateFormat date = new SimpleDateFormat ("yyyyMMdd-HHmmss");
 		final String timeStamp = date.format (Calendar.getInstance ()
-				.getTime ());
+			.getTime ());
 		final String fileName = "%s/%s-%s.%s";
 		captureScreenshot (format (fileName, path, prefix, timeStamp, "jpeg"));
 	}
@@ -111,7 +108,8 @@ public class DeviceActions <D extends AppiumDriver <MobileElement>, E extends De
 		log.info ("Hiding the keyboard...");
 		try {
 			this.driver.hideKeyboard ();
-		} catch (final NoSuchSessionException e) {
+		}
+		catch (final NoSuchSessionException e) {
 			fail (AppiumServerStoppedError.class, SERVER_STOPPED, e);
 		}
 	}
@@ -134,7 +132,7 @@ public class DeviceActions <D extends AppiumDriver <MobileElement>, E extends De
 	public void pinch (final int distance) {
 		log.info (format ("Pinching on device screen by [%d]% distance...", distance));
 		doubleFingerGesture (SwipeDirection.DOWN, SwipeDirection.UP, SwipeStartPosition.TOP,
-				SwipeStartPosition.BOTTOM, distance);
+			SwipeStartPosition.BOTTOM, distance);
 	}
 
 	/**
@@ -145,10 +143,10 @@ public class DeviceActions <D extends AppiumDriver <MobileElement>, E extends De
 	 * @param distance
 	 */
 	public void swipe (final SwipeDirection direction, final SwipeStartPosition start,
-			final int distance) {
+		final int distance) {
 		log.info (format (
-				"Swiping [%s] on device screen by [%d] perc distance from [%s] of the screen...",
-				direction, distance, start));
+			"Swiping [%s] on device screen by [%d] perc distance from [%s] of the screen...",
+			direction, distance, start));
 		swipeTo (direction, start, distance).perform ();
 	}
 
@@ -160,7 +158,7 @@ public class DeviceActions <D extends AppiumDriver <MobileElement>, E extends De
 	public void zoom (final int distance) {
 		log.info (format ("Zooming in device screen by [%d]% distance...", distance));
 		doubleFingerGesture (SwipeDirection.UP, SwipeDirection.DOWN, SwipeStartPosition.CENTER,
-				SwipeStartPosition.CENTER, distance);
+			SwipeStartPosition.CENTER, distance);
 	}
 
 	/**
@@ -174,28 +172,29 @@ public class DeviceActions <D extends AppiumDriver <MobileElement>, E extends De
 		try {
 			final File srcFiler = this.driver.getScreenshotAs (OutputType.FILE);
 			copyFile (srcFiler, path);
-		} catch (final NoSuchSessionException e) {
+		}
+		catch (final NoSuchSessionException e) {
 			fail (AppiumServerStoppedError.class, SERVER_STOPPED, e);
 		}
 	}
 
 	private void doubleFingerGesture (final SwipeDirection finger1, final SwipeDirection finger2,
-			final SwipeStartPosition start1, final SwipeStartPosition start2,
-			final int distancePercent) {
+		final SwipeStartPosition start1, final SwipeStartPosition start2,
+		final int distancePercent) {
 		final T firstFinger = swipeTo (finger1, start1, distancePercent);
 		final T secondFinger = swipeTo (finger2, start2, distancePercent);
 		final MultiTouchAction multiTouch = new MultiTouchAction (this.driver);
 		multiTouch.add (firstFinger)
-				.add (secondFinger)
-				.perform ();
+			.add (secondFinger)
+			.perform ();
 	}
 
 	private T swipeTo (final SwipeDirection direction, final SwipeStartPosition start,
-			final int distancePercent) {
+		final int distancePercent) {
 		return SwipeUtils.swipeTo (direction, start, distancePercent, this.setting,
-				this.driver.manage ()
-						.window ()
-						.getSize (),
-				null, null, this.actions);
+			this.driver.manage ()
+				.window ()
+				.getSize (),
+			null, null, this.actions);
 	}
 }

--- a/src/main/java/com/github/wasiqb/coteafs/appium/device/DeviceActivity.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/device/DeviceActivity.java
@@ -53,11 +53,7 @@ import io.appium.java_client.TouchAction;
  * @since 26-Apr-2017 4:31:24 PM
  */
 public abstract class DeviceActivity <D extends AppiumDriver <MobileElement>, E extends Device <D, T>, T extends TouchAction <T>> {
-	private static final Logger log;
-
-	static {
-		log = LogManager.getLogger (DeviceActivity.class);
-	}
+	private static final Logger log = LogManager.getLogger (DeviceActivity.class);
 
 	protected final E							device;
 	protected final Map <String, DeviceElement>	deviceElements;
@@ -76,7 +72,7 @@ public abstract class DeviceActivity <D extends AppiumDriver <MobileElement>, E 
 		this.touch = touch;
 		this.deviceElements = new HashMap <> ();
 		this.setting = device.getSetting ()
-				.getPlayback ();
+			.getPlayback ();
 		this.wait = new WebDriverWait (device.getDriver (), this.setting.getWaitForElementUntil ());
 	}
 
@@ -146,7 +142,7 @@ public abstract class DeviceActivity <D extends AppiumDriver <MobileElement>, E 
 	}
 
 	private MobileElement find (final D deviceDriver, final DeviceElement parent, final By locator,
-			final int index, final WaitStrategy strategy) {
+		final int index, final WaitStrategy strategy) {
 		try {
 			wait (locator, strategy);
 			List <MobileElement> result = null;
@@ -155,30 +151,36 @@ public abstract class DeviceActivity <D extends AppiumDriver <MobileElement>, E 
 				log.trace (String.format (message, parent.name (), locator, index));
 				final MobileElement mobileElement = getElement (parent.name ());
 				result = mobileElement.findElements (locator);
-			} else {
+			}
+			else {
 				final String message = "Finding root element using [%s] at index [%d]...";
 				log.trace (String.format (message, locator, index));
 				result = deviceDriver.findElements (locator);
 			}
 			return result.get (index);
-		} catch (final TimeoutException e) {
+		}
+		catch (final TimeoutException e) {
 			captureScreenshotOnError ();
 			final String message = "[%s] locator timed out.";
 			fail (DeviceElementFindTimedOutError.class, String.format (message, locator), e);
-		} catch (final NoSuchSessionException e) {
+		}
+		catch (final NoSuchSessionException e) {
 			fail (AppiumServerStoppedError.class, SERVER_STOPPED, e);
-		} catch (final InvalidSelectorException e) {
+		}
+		catch (final InvalidSelectorException e) {
 			fail (AppiumSelectorNotImplementedError.class, "Selector not supported", e);
-		} catch (final Exception e) {
+		}
+		catch (final Exception e) {
 			captureScreenshotOnError ();
 			String message = "";
 			if (parent == null) {
 				message = "Error occured while finding root device element with locator [%s] at index [%d].";
 				fail (DeviceElementNotFoundError.class, String.format (message, locator, index), e);
-			} else {
+			}
+			else {
 				message = "Error occured while finding device element with locator [%s] at index [%d] under parent %s.";
 				fail (DeviceElementNotFoundError.class,
-						String.format (message, locator, index, parent.name ()), e);
+					String.format (message, locator, index, parent.name ()), e);
 			}
 		}
 		return null;

--- a/src/main/java/com/github/wasiqb/coteafs/appium/ios/IOSDevice.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/ios/IOSDevice.java
@@ -15,6 +15,9 @@
  */
 package com.github.wasiqb.coteafs.appium.ios;
 
+import static io.appium.java_client.ios.IOSStartScreenRecordingOptions.startScreenRecordingOptions;
+import static io.appium.java_client.ios.IOSStopScreenRecordingOptions.stopScreenRecordingOptions;
+
 import com.github.wasiqb.coteafs.appium.device.Device;
 import com.github.wasiqb.coteafs.appium.service.AppiumServer;
 
@@ -35,5 +38,30 @@ public class IOSDevice extends Device <IOSDriver <MobileElement>, IOSTouchAction
 	 */
 	public IOSDevice (final AppiumServer server, final String name) {
 		super (server, name);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see com.github.wasiqb.coteafs.appium.device.Device#startRecord()
+	 */
+	@Override
+	protected void startRecord () {
+		if (this.setting.getPlayback ()
+			.isRecord ()) {
+			this.driver.startRecordingScreen (startScreenRecordingOptions ());
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see com.github.wasiqb.coteafs.appium.device.Device#stopRecord()
+	 */
+	@Override
+	protected void stopRecord () {
+		if (this.setting.getPlayback ()
+			.isRecord ()) {
+			final String content = this.driver.stopRecordingScreen (stopScreenRecordingOptions ());
+			saveRecording (content);
+		}
 	}
 }

--- a/src/main/java/com/github/wasiqb/coteafs/appium/ios/IOSDevice.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/ios/IOSDevice.java
@@ -15,14 +15,13 @@
  */
 package com.github.wasiqb.coteafs.appium.ios;
 
-import static io.appium.java_client.ios.IOSStartScreenRecordingOptions.startScreenRecordingOptions;
-import static io.appium.java_client.ios.IOSStopScreenRecordingOptions.stopScreenRecordingOptions;
-
 import com.github.wasiqb.coteafs.appium.device.Device;
 import com.github.wasiqb.coteafs.appium.service.AppiumServer;
 
 import io.appium.java_client.MobileElement;
 import io.appium.java_client.ios.IOSDriver;
+import io.appium.java_client.ios.IOSStartScreenRecordingOptions;
+import io.appium.java_client.ios.IOSStopScreenRecordingOptions;
 import io.appium.java_client.ios.IOSTouchAction;
 
 /**
@@ -42,26 +41,21 @@ public class IOSDevice extends Device <IOSDriver <MobileElement>, IOSTouchAction
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.github.wasiqb.coteafs.appium.device.Device#startRecord()
+	 * @see com.github.wasiqb.coteafs.appium.device.Device#startRecordSetting()
 	 */
+	@SuppressWarnings ("unchecked")
 	@Override
-	protected void startRecord () {
-		if (this.setting.getPlayback ()
-			.isRecord ()) {
-			this.driver.startRecordingScreen (startScreenRecordingOptions ());
-		}
+	protected IOSStartScreenRecordingOptions startRecordSetting () {
+		return IOSStartScreenRecordingOptions.startScreenRecordingOptions ();
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.github.wasiqb.coteafs.appium.device.Device#stopRecord()
+	 * @see com.github.wasiqb.coteafs.appium.device.Device#stopRecordSetting()
 	 */
+	@SuppressWarnings ("unchecked")
 	@Override
-	protected void stopRecord () {
-		if (this.setting.getPlayback ()
-			.isRecord ()) {
-			final String content = this.driver.stopRecordingScreen (stopScreenRecordingOptions ());
-			saveRecording (content);
-		}
+	protected IOSStopScreenRecordingOptions stopRecordSetting () {
+		return IOSStopScreenRecordingOptions.stopScreenRecordingOptions ();
 	}
 }

--- a/src/main/java/com/github/wasiqb/coteafs/appium/ios/IOSDevice.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/ios/IOSDevice.java
@@ -15,12 +15,14 @@
  */
 package com.github.wasiqb.coteafs.appium.ios;
 
+import com.github.wasiqb.coteafs.appium.config.RecordSetting;
 import com.github.wasiqb.coteafs.appium.device.Device;
 import com.github.wasiqb.coteafs.appium.service.AppiumServer;
 
 import io.appium.java_client.MobileElement;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.ios.IOSStartScreenRecordingOptions;
+import io.appium.java_client.ios.IOSStartScreenRecordingOptions.VideoQuality;
 import io.appium.java_client.ios.IOSStopScreenRecordingOptions;
 import io.appium.java_client.ios.IOSTouchAction;
 
@@ -46,7 +48,14 @@ public class IOSDevice extends Device <IOSDriver <MobileElement>, IOSTouchAction
 	@SuppressWarnings ("unchecked")
 	@Override
 	protected IOSStartScreenRecordingOptions startRecordSetting () {
-		return IOSStartScreenRecordingOptions.startScreenRecordingOptions ();
+		final IOSStartScreenRecordingOptions options = IOSStartScreenRecordingOptions
+			.startScreenRecordingOptions ();
+		final RecordSetting record = this.setting.getPlayback ()
+			.getRecord ();
+		if (record.getQuality () != VideoQuality.MEDIUM) {
+			options.withVideoQuality (record.getQuality ());
+		}
+		return options;
 	}
 
 	/*

--- a/src/main/java/com/github/wasiqb/coteafs/appium/utils/BatteryHealth.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/utils/BatteryHealth.java
@@ -38,14 +38,14 @@ public final class BatteryHealth {
 	 */
 	public static void check (final String state, final double level) {
 		log.trace (format ("Current Battery status is [{0}] with charge level as [{1}%]...", state,
-				level * 100));
+			level * 100));
 		if (!state.equals ("CHARGING") && !state.equals ("FULL") && level < 0.2) {
 			fail (NotEnoughBatteryChargeError.class,
-					"Battery does not have enough charging, to continue, put your device on USB...");
+				"Battery does not have enough charging, to continue, put your device on USB...");
 		}
 	}
 
 	private BatteryHealth () {
-		// TODO Auto-generated constructor stub
+		// Utility class.
 	}
 }

--- a/src/main/java/com/github/wasiqb/coteafs/appium/utils/ScreenRecorder.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/utils/ScreenRecorder.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2017-2020, Wasiq Bhamla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.wasiqb.coteafs.appium.utils;
+
+import static java.lang.String.format;
+import static org.apache.commons.io.FileUtils.writeByteArrayToFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Base64;
+import java.util.Calendar;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.github.wasiqb.coteafs.appium.config.RecordSetting;
+
+/**
+ * @author wasiqb
+ * @since Oct 13, 2018
+ */
+public class ScreenRecorder {
+	private static final Logger LOG = LogManager.getLogger (ScreenRecorder.class);
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 * @param content
+	 * @param setting
+	 */
+	public static void saveRecording (final String content, final RecordSetting setting) {
+		final byte [] decode = Base64.getDecoder ()
+			.decode (content);
+		try {
+			final String path = setting.getPath ();
+			final String prefix = setting.getPrefix ();
+			final SimpleDateFormat date = new SimpleDateFormat ("yyyyMMdd-HHmmss");
+			final String timeStamp = date.format (Calendar.getInstance ()
+				.getTime ());
+			final String fileName = format ("%s/%s-%s.%s", path, prefix, timeStamp, "mp4");
+			LOG.info (format ("Saving video recording to [%s] path...", fileName));
+			writeByteArrayToFile (new File (fileName), decode);
+		}
+		catch (final IOException e) {
+			LOG.error ("Error occurred while saving video recording...");
+			LOG.catching (e);
+		}
+	}
+
+	private ScreenRecorder () {
+		// Utility class.
+	}
+}

--- a/src/test/java/com/github/wasiqb/coteafs/appium/android/DefaultTest.java
+++ b/src/test/java/com/github/wasiqb/coteafs/appium/android/DefaultTest.java
@@ -15,7 +15,9 @@
  */
 package com.github.wasiqb.coteafs.appium.android;
 
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Parameters;
 
@@ -31,6 +33,15 @@ public class DefaultTest {
 	protected AndroidDevice	androidDevice;
 	protected MainActivity	main;
 	private AppiumServer	androidServer;
+
+	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 */
+	@BeforeMethod
+	public void setupMethod () {
+		this.androidDevice.startRecording ();
+	}
 
 	/**
 	 * @author wasiq.bhamla
@@ -53,6 +64,15 @@ public class DefaultTest {
 	}
 
 	/**
+	 * @author wasiqb
+	 * @since Oct 13, 2018
+	 */
+	@AfterMethod
+	public void teardownMethod () {
+		this.androidDevice.stopRecording ();
+	}
+
+	/**
 	 * @author wasiq.bhamla
 	 * @since 17-Apr-2017 3:47:41 PM
 	 */
@@ -65,7 +85,7 @@ public class DefaultTest {
 	private void login () {
 		final LoginActivityAction login = new LoginActivityAction (this.androidDevice);
 		login.addInputValue ("UserName", "admin")
-				.addInputValue ("Password", "admin")
-				.perform ();
+			.addInputValue ("Password", "admin")
+			.perform ();
 	}
 }

--- a/src/test/java/com/github/wasiqb/coteafs/appium/android/VodQATest.java
+++ b/src/test/java/com/github/wasiqb/coteafs/appium/android/VodQATest.java
@@ -39,14 +39,14 @@ public class VodQATest extends DefaultTest {
 	@Test
 	public void testDragDrop () {
 		this.main.onElement ("DragDrop")
-				.click ();
+			.click ();
 
 		final DragDropActivity dd = new DragDropActivity (this.androidDevice);
 		dd.onElement ("DropMe")
-				.dragDrop (dd.getElement ("DropZone"));
+			.dragDrop (dd.getElement ("DropZone"));
 		dd.onElement ("Success")
-				.verifyThat ()
-				.textShouldBeEqualTo ("Circle dropped");
+			.verifyThat ()
+			.textShouldBeEqualTo ("Circle dropped");
 	}
 
 	/**
@@ -56,13 +56,13 @@ public class VodQATest extends DefaultTest {
 	@Test
 	public void testLongPress () {
 		this.main.onElement ("LongPress")
-				.click ();
+			.click ();
 
 		final LongPressActivity lp = new LongPressActivity (this.androidDevice);
 		lp.onElement ("Button")
-				.longPress ();
+			.longPress ();
 		final String message = lp.onDevice ()
-				.handleAlert ();
+			.handleAlert ();
 		Assert.assertEquals (message, "you pressed me hard :P");
 	}
 
@@ -74,18 +74,18 @@ public class VodQATest extends DefaultTest {
 	@Test
 	public void testNativeView () throws InterruptedException {
 		this.main.onElement ("ChainedView")
-				.click ();
+			.click ();
 
 		final ChainedViewActivity chained = new ChainedViewActivity (this.androidDevice);
 		chained.onElement ("Text1")
-				.verifyThat ()
-				.textShouldBeEqualTo ("Hello World, I'm View one ");
+			.verifyThat ()
+			.textShouldBeEqualTo ("Hello World, I'm View one ");
 		chained.onElement ("Text2")
-				.verifyThat ()
-				.textShouldBeEqualTo ("Hello World, I'm View two ");
+			.verifyThat ()
+			.textShouldBeEqualTo ("Hello World, I'm View two ");
 		chained.onElement ("Text3")
-				.verifyThat ()
-				.textShouldBeEqualTo ("Hello World, I'm View three ");
+			.verifyThat ()
+			.textShouldBeEqualTo ("Hello World, I'm View three ");
 	}
 
 	/**
@@ -95,13 +95,13 @@ public class VodQATest extends DefaultTest {
 	@Test
 	public void testSlider () {
 		this.main.onElement ("Slider")
-				.click ();
+			.click ();
 
 		final SliderActivity slide = new SliderActivity (this.androidDevice);
 		slide.onElement ("Slider")
-				.swipe (SwipeDirection.RIGHT, SwipeStartPosition.LEFT, 75);
+			.swipe (SwipeDirection.RIGHT, SwipeStartPosition.LEFT, 75);
 		slide.onElement ("Slider1")
-				.swipe (SwipeDirection.LEFT, SwipeStartPosition.RIGHT, 75);
+			.swipe (SwipeDirection.LEFT, SwipeStartPosition.RIGHT, 75);
 	}
 
 	/**
@@ -111,13 +111,13 @@ public class VodQATest extends DefaultTest {
 	@Test
 	public void testVerticleSwipe () {
 		this.main.onElement ("VerticalSwipe")
-				.click ();
+			.click ();
 
 		final VerticleSwipeActivity vs = new VerticleSwipeActivity (this.androidDevice);
 		vs.onElement ("List")
-				.swipe (SwipeDirection.UP, SwipeStartPosition.BOTTOM, 25);
+			.swipe (SwipeDirection.UP, SwipeStartPosition.BOTTOM, 25);
 		vs.onElement ("List")
-				.swipe (SwipeDirection.DOWN, SwipeStartPosition.TOP, 25);
+			.swipe (SwipeDirection.DOWN, SwipeStartPosition.TOP, 25);
 	}
 
 	/**
@@ -127,13 +127,13 @@ public class VodQATest extends DefaultTest {
 	@Test
 	public void testZoomPinch () {
 		this.main.onElement ("PhotoView")
-				.click ();
+			.click ();
 
 		final PhotoViewActivity p = new PhotoViewActivity (this.androidDevice);
 		p.onElement ("Img")
-				.zoom (25);
+			.zoom (25);
 
 		p.onElement ("Img")
-				.pinch (25);
+			.pinch (25);
 	}
 }

--- a/src/test/java/com/github/wasiqb/coteafs/appium/android/vodqa/actions/LoginActivityAction.java
+++ b/src/test/java/com/github/wasiqb/coteafs/appium/android/vodqa/actions/LoginActivityAction.java
@@ -40,13 +40,13 @@ public class LoginActivityAction extends AndroidActivityActions {
 	@Override
 	public void perform () {
 		final LoginActivity login = new LoginActivity (getDevice ());
-		// login.onElement ("UserName")
-		// .enterText (value ("UserName"));
-		// login.onElement ("Password")
-		// .enterText (value ("Password"));
-		// login.onDevice ()
-		// .hideKeyboard ();
+		login.onElement ("UserName")
+				.enterText (value ("UserName"));
+		login.onElement ("Password")
+				.enterText (value ("Password"));
+		login.onDevice ()
+				.hideKeyboard ();
 		login.onElement ("Login")
-			.tap ();
+				.tap ();
 	}
 }

--- a/src/test/java/com/github/wasiqb/coteafs/appium/android/vodqa/activities/MainActivity.java
+++ b/src/test/java/com/github/wasiqb/coteafs/appium/android/vodqa/activities/MainActivity.java
@@ -17,7 +17,6 @@ package com.github.wasiqb.coteafs.appium.android.vodqa.activities;
 
 import com.github.wasiqb.coteafs.appium.android.AndroidDevice;
 import com.github.wasiqb.coteafs.appium.device.DeviceElement;
-import com.github.wasiqb.coteafs.appium.device.WaitStrategy;
 
 import io.appium.java_client.MobileBy;
 
@@ -49,35 +48,27 @@ public class MainActivity extends DefaultActivity {
 
 		DeviceElement.create ("ChainedView")
 			.parent (scroll)
-			.waitStrategy (WaitStrategy.ENABLED)
 			.using (MobileBy.AccessibilityId ("chainedView"));
 		DeviceElement.create ("Slider")
 			.parent (scroll)
-			.waitStrategy (WaitStrategy.ENABLED)
 			.using (MobileBy.AccessibilityId ("slider1"));
 		DeviceElement.create ("VerticalSwipe")
 			.parent (scroll)
-			.waitStrategy (WaitStrategy.ENABLED)
 			.using (MobileBy.AccessibilityId ("verticalSwipe"));
 		DeviceElement.create ("DragDrop")
 			.parent (scroll)
-			.waitStrategy (WaitStrategy.ENABLED)
 			.using (MobileBy.AccessibilityId ("dragAndDrop"));
 		DeviceElement.create ("DoubleTap")
 			.parent (scroll)
-			.waitStrategy (WaitStrategy.ENABLED)
 			.using (MobileBy.AccessibilityId ("doubleTap"));
 		DeviceElement.create ("WebView")
 			.parent (scroll)
-			.waitStrategy (WaitStrategy.ENABLED)
 			.using (MobileBy.AccessibilityId ("webView"));
 		DeviceElement.create ("LongPress")
 			.parent (scroll)
-			.waitStrategy (WaitStrategy.ENABLED)
 			.using (MobileBy.AccessibilityId ("longPress"));
 		DeviceElement.create ("PhotoView")
 			.parent (scroll)
-			.waitStrategy (WaitStrategy.ENABLED)
 			.using (MobileBy.AccessibilityId ("photoView"));
 
 		return main;

--- a/src/test/resources/appium-config.yaml
+++ b/src/test/resources/appium-config.yaml
@@ -15,21 +15,21 @@ servers:
     protocol: HTTPS
     host: hub-cloud.browserstack.com
     cloud: true
-    external: true
     user_name: ${env.user}
     password: ${env.pass}
 
 devices:
   test_local:
     platform_type: ANDROID
-    device_name: Samsung Galaxy S8
+    device_name: MI Redmi Note 4
     device_version: 7.0
     app_type: HYBRID
     device_type: REAL
-    automation_name: UIAUTOMATOR2
+    automation_name: APPIUM
     app_location: apps/android/VodQA.apk
     session_timeout: 120000
     playback:
+      record: true
       delay_before_swipe: 2
       delay_after_swipe: 1
       delay_before_tap: 2
@@ -40,11 +40,12 @@ devices:
     device_version: 7.0
     app_type: HYBRID
     device_type: REAL
-    automation_name: UIAUTOMATOR2
+    automation_name: APPIUM
     app_location: ${env.app}
     cloud_app: true
     session_timeout: 120000
     playback:
+      record: true
       delay_before_swipe: 2
       delay_after_swipe: 1
       delay_before_tap: 2

--- a/src/test/resources/appium-config.yaml
+++ b/src/test/resources/appium-config.yaml
@@ -29,7 +29,8 @@ devices:
     app_location: apps/android/VodQA.apk
     session_timeout: 120000
     playback:
-      record: true
+      record:
+        enabled: true
       delay_before_swipe: 2
       delay_after_swipe: 1
       delay_before_tap: 2
@@ -45,7 +46,8 @@ devices:
     cloud_app: true
     session_timeout: 120000
     playback:
-      record: true
+      record:
+        enabled: true
       delay_before_swipe: 2
       delay_after_swipe: 1
       delay_before_tap: 2

--- a/testng.xml
+++ b/testng.xml
@@ -5,7 +5,11 @@
 		<parameter name="server" value="android" />
 		<parameter name="device" value="test_local" />
 		<classes>
-			<class name="com.github.wasiqb.coteafs.appium.android.VodQATest" />
+			<class name="com.github.wasiqb.coteafs.appium.android.VodQATest">
+				<methods>
+					<include name="testLongPress" />
+				</methods>
+			</class>
 		</classes>
 	</test> <!-- Android Test -->
 </suite> <!-- coteafs-appium Test Suite -->


### PR DESCRIPTION
## Change list

Allows video recording for both Android and iOS.

### New Config settings:
- [x] `record`: A new block under `playback` setting.
- [x] `enabled`: Identifies whether the feature is enabled or not.
- [x] `bit_rate`: an int value which takes in max as 20 MB/s. **Only for Android**
- [x] `duration`: an int indicates minutes. (_3 mins max for Android and 10 mins max for iOS_)
- [x] `path`: Folder location where the videos will be saved.
- [x] `prefix`: Prefix for file. Default is **VID**.
- [x] `quality`: Video Quality for the video. Allowed values are `LOW`, `MEDIUM`, `HIGH`, `PHOTO`. Default is `MEDIUM`. **Only for iOS**.
- [x] `size`: Size of the video based on Dimension. **Only for Android**.

### New methods in all device classes
This will be functional only when recording is enabled in the config.
- [x] `startRecording`: Calling this will start recording.
- [x] `stopRecording`: Calling this will stop and save the recording to the configured path.