### PR TITLE
Updated dependencies for Appium, Selenium and other supporting librar…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /bin/
 /screenshots/
 /videos/
+/.idea/
+*.iml
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.github.wasiqb.coteafs</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.1.0</version>
+		<version>2.2.0</version>
 	</parent>
 
 	<scm>
@@ -31,12 +31,13 @@
 	</ciManagement>
 
 	<properties>
-		<appium-version>6.1.0</appium-version>
-		<selenium-version>3.141.5</selenium-version>
-		<coteafs.config.version>1.7.0</coteafs.config.version>
-		<coteafs.error.version>1.6.0</coteafs.error.version>
-		<coteafs.logger.version>1.7.0</coteafs.logger.version>
-		<commons.text.version>1.6</commons.text.version>
+		<appium-version>7.0.0</appium-version>
+		<selenium-version>4.0.0-alpha-2</selenium-version>
+		<coteafs.selenium.version>2.0.0</coteafs.selenium.version>
+		<coteafs.config.version>1.8.0</coteafs.config.version>
+		<coteafs.error.version>1.7.0</coteafs.error.version>
+		<coteafs.logger.version>1.8.0</coteafs.logger.version>
+		<commons.text.version>1.7</commons.text.version>
 		<coteafs.listeners.version>1.2.0</coteafs.listeners.version>
 	</properties>
 
@@ -61,6 +62,11 @@
 			<groupId>com.github.wasiqb.coteafs</groupId>
 			<artifactId>error</artifactId>
 			<version>${coteafs.error.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.wasiqb.coteafs</groupId>
+			<artifactId>selenium</artifactId>
+			<version>${coteafs.selenium.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.wasiqb.coteafs</groupId>

--- a/src/main/java/com/github/wasiqb/coteafs/appium/device/DeviceActions.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/device/DeviceActions.java
@@ -18,6 +18,7 @@ package com.github.wasiqb.coteafs.appium.device;
 import static com.github.wasiqb.coteafs.appium.constants.ErrorMessage.SERVER_STOPPED;
 import static com.github.wasiqb.coteafs.appium.utils.ErrorUtils.fail;
 import static java.lang.String.format;
+import static java.time.Duration.ofSeconds;
 
 import java.io.File;
 import java.io.IOException;
@@ -70,11 +71,11 @@ public class DeviceActions <D extends AppiumDriver <MobileElement>, E extends De
 		}
 	}
 
+	private final T					actions;
+	private final PlaybackSetting	setting;
 	protected final E				device;
 	protected final D				driver;
 	protected final WebDriverWait	wait;
-	private final T					actions;
-	private final PlaybackSetting	setting;
 
 	/**
 	 * @author wasiq.bhamla
@@ -87,7 +88,8 @@ public class DeviceActions <D extends AppiumDriver <MobileElement>, E extends De
 		this.actions = actions;
 		this.driver = this.device.getDriver ();
 		this.setting = device.setting.getPlayback ();
-		this.wait = new WebDriverWait (this.driver, this.setting.getWaitForElementUntil ());
+		this.wait = new WebDriverWait (this.driver,
+			ofSeconds (this.setting.getWaitForElementUntil ()));
 	}
 
 	/**

--- a/src/main/java/com/github/wasiqb/coteafs/appium/device/DeviceActivity.java
+++ b/src/main/java/com/github/wasiqb/coteafs/appium/device/DeviceActivity.java
@@ -17,6 +17,7 @@ package com.github.wasiqb.coteafs.appium.device;
 
 import static com.github.wasiqb.coteafs.appium.constants.ErrorMessage.SERVER_STOPPED;
 import static com.github.wasiqb.coteafs.appium.utils.ErrorUtils.fail;
+import static java.time.Duration.ofSeconds;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfAllElementsLocatedBy;
 
 import java.util.HashMap;
@@ -57,16 +58,16 @@ import io.appium.java_client.TouchAction;
  */
 public abstract class DeviceActivity <D extends AppiumDriver <MobileElement>,
 	E extends Device <D, T>, T extends TouchAction <T>> {
-	private static final Logger log = LogManager.getLogger (DeviceActivity.class);
+	private static final Logger					log	= LogManager.getLogger (DeviceActivity.class);
 
-	protected final AutomationType				automation;
-	protected final E							device;
-	protected final Map <String, DeviceElement>	deviceElements;
-	protected final PlatformType				platform;
 	private final DeviceSetting					deviceSetting;
 	private final PlaybackSetting				playSetting;
 	private final T								touch;
 	private final WebDriverWait					wait;
+	protected final AutomationType				automation;
+	protected final E							device;
+	protected final Map <String, DeviceElement>	deviceElements;
+	protected final PlatformType				platform;
 
 	/**
 	 * @author wasiq.bhamla
@@ -83,7 +84,7 @@ public abstract class DeviceActivity <D extends AppiumDriver <MobileElement>,
 		this.platform = this.deviceSetting.getPlatformType ();
 		this.playSetting = this.deviceSetting.getPlayback ();
 		this.wait = new WebDriverWait (device.getDriver (),
-			this.playSetting.getWaitForElementUntil ());
+			ofSeconds (this.playSetting.getWaitForElementUntil ()));
 	}
 
 	/**
@@ -137,13 +138,6 @@ public abstract class DeviceActivity <D extends AppiumDriver <MobileElement>,
 		final DeviceElement element = getDeviceElement (name).index (index);
 		return new DeviceElementActions <> (this.device, name, findElements (element), this.touch);
 	}
-
-	/**
-	 * @author wasiq.bhamla
-	 * @return element
-	 * @since 02-May-2017 4:38:00 PM
-	 */
-	protected abstract DeviceElement prepare ();
 
 	private void captureScreenshotOnError () {
 		if (this.playSetting.isScreenshotOnError ()) {
@@ -205,8 +199,7 @@ public abstract class DeviceActivity <D extends AppiumDriver <MobileElement>,
 	}
 
 	private DeviceElement getDeviceElement (final String name) {
-		if (this.deviceElements.containsKey (name))
-			return this.deviceElements.get (name);
+		if (this.deviceElements.containsKey (name)) return this.deviceElements.get (name);
 		final String msg = "DeviceElement with name [%s] not found.";
 		fail (DeviceElementNameNotFoundError.class, String.format (msg, name));
 		return null;
@@ -253,4 +246,11 @@ public abstract class DeviceActivity <D extends AppiumDriver <MobileElement>,
 				break;
 		}
 	}
+
+	/**
+	 * @author wasiq.bhamla
+	 * @return element
+	 * @since 02-May-2017 4:38:00 PM
+	 */
+	protected abstract DeviceElement prepare ();
 }


### PR DESCRIPTION
## Change list

Updated dependency of Appium java client to latest stable version 7.0.
 
## Types of changes

- [x] Added `Duration` class support for deprecated `WebDriverWait` constructor.